### PR TITLE
Logging merge

### DIFF
--- a/clusters/dev/flux-system/gotk-sync.yaml
+++ b/clusters/dev/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: logging2
   secretRef:
     name: flux-system
   url: https://github.com/ssi-dk/sofi_core_gitops.git

--- a/clusters/dev/flux-system/gotk-sync.yaml
+++ b/clusters/dev/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: logging2
+    branch: main
   secretRef:
     name: flux-system
   url: https://github.com/ssi-dk/sofi_core_gitops.git

--- a/infrastructure/controllers/dev/alloy/release.yaml
+++ b/infrastructure/controllers/dev/alloy/release.yaml
@@ -18,7 +18,7 @@ spec:
         name: alloy-config
         content: |-
           logging {
-            level = "info"
+            level = "debug"
             format = "logfmt"
           }
           loki.write "default" {

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -31,6 +31,7 @@ spec:
     grafana.ini:
       server:
         root_url: https://dev2.sofi-platform.dk/grafana
+        serve_from_sub_path: true
 
     datasources:
       datasources.yaml:

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -20,7 +20,7 @@ spec:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: traefik
-      path: /grafana/?(.*)
+      path: /grafana
       hosts:
          - dev2.sofi-platform.dk
 
@@ -30,6 +30,7 @@ spec:
     
     grafana.ini:
       server:
+        domain: dev2.sofi-platform.dk
         root_url: https://dev2.sofi-platform.dk/grafana
         serve_from_sub_path: true
 

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -26,8 +26,8 @@ spec:
       annotations:
         kubernetes.io/ingress.class: "traefik"
 
-    adminUser: admin
-    adminPassword: admin
+    adminUser: admin123
+    adminPassword: admin123
 
     service:
       type: ClusterIP

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -21,7 +21,7 @@ spec:
       ingressClassName: traefik
       annotations:
         kubernetes.io/ingress.class: traefik
-      path: /grafana
+      path: /grafana/
       hosts:
          - dev2.sofi-platform.dk
         

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -19,16 +19,23 @@ spec:
     ingress:
       enabled: true
       ingressClassName: traefik
-      hostname: dev2.sofi-platform.dk
+      hosts:
+         - dev2.sofi-platform.dk
       path: /grafana
       pathType: Prefix
       # tls: true
       annotations:
-        kubernetes.io/ingress.class: "traefik"
+        kubernetes.io/ingress.class: traefik
 
     service:
       type: ClusterIP
       port: 80
+    
+    grafana:
+      ini:
+        server:
+          root_url: https://dev2.sofi-platform.dk/grafana
+          serve_from_subpath: true
 
     datasources:
       datasources.yaml:

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -26,9 +26,9 @@ spec:
          - dev2.sofi-platform.dk
         
       tls:
-      - hosts:
-          - dev2.sofi-platform.dk
-        secretName: dev2.sofi-platform.dk-tls
+        - hosts:
+            - dev2.sofi-platform.dk
+          secretName: dev2.sofi-platform.dk-tls
 
     service:
       type: ClusterIP

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -18,24 +18,19 @@ spec:
 
     ingress:
       enabled: true
-      ingressClassName: traefik
-      hosts:
-         - dev2.sofi-platform.dk
-      path: /grafana
-      pathType: Prefix
-      # tls: true
       annotations:
         kubernetes.io/ingress.class: traefik
+      path: /grafana/?(.*)
+      hosts:
+         - dev2.sofi-platform.dk
 
     service:
       type: ClusterIP
       port: 80
     
-    grafana:
-      ini:
-        server:
-          root_url: https://dev2.sofi-platform.dk/grafana
-          serve_from_subpath: true
+    grafana.ini:
+      server:
+        root_url: https://dev2.sofi-platform.dk/grafana
 
     datasources:
       datasources.yaml:

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -22,12 +22,9 @@ spec:
       hostname: dev2.sofi-platform.dk
       path: /grafana
       pathType: Prefix
-      tls: true
+      # tls: true
       annotations:
         kubernetes.io/ingress.class: "traefik"
-
-    adminUser: admin123
-    adminPassword: admin123
 
     service:
       type: ClusterIP

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -25,8 +25,6 @@ spec:
       tls: true
       annotations:
         kubernetes.io/ingress.class: "traefik"
-      annotations:
-        kubernetes.io/ingress.class: "traefik"
 
     adminUser: admin
     adminPassword: admin

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -23,6 +23,11 @@ spec:
       path: /grafana
       hosts:
          - dev2.sofi-platform.dk
+        
+      tls:
+      - hosts:
+          - dev2.sofi-platform.dk
+        secretName: dev2.sofi-platform.dk-tls
 
     service:
       type: ClusterIP
@@ -31,7 +36,7 @@ spec:
     grafana.ini:
       server:
         domain: dev2.sofi-platform.dk
-        root_url: https://dev2.sofi-platform.dk/grafana
+        root_url: https://dev2.sofi-platform.dk/grafana/
         serve_from_sub_path: true
 
     datasources:

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -21,9 +21,8 @@ spec:
       ingressClassName: traefik
       hosts:
         - dev2.sofi-platform.dk
-      paths:
-        - path: /grafana
-          pathType: Prefix
+      path: /grafana
+      pathType: Prefix
       tls:
         - secretName: dev2.sofi-platform.dk-tls
           hosts:

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -21,6 +21,7 @@ spec:
       ingressClassName: traefik
       hosts:
         - dev2.sofi-platform.dk
+        - 172.23.72.51
       path: /grafana
       pathType: Prefix
       tls:

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -18,6 +18,7 @@ spec:
 
     ingress:
       enabled: true
+      ingressClassName: traefik
       annotations:
         kubernetes.io/ingress.class: traefik
       path: /grafana

--- a/infrastructure/controllers/dev/grafana/release.yaml
+++ b/infrastructure/controllers/dev/grafana/release.yaml
@@ -19,15 +19,12 @@ spec:
     ingress:
       enabled: true
       ingressClassName: traefik
-      hosts:
-        - dev2.sofi-platform.dk
-        - 172.23.72.51
+      hostname: dev2.sofi-platform.dk
       path: /grafana
       pathType: Prefix
-      tls:
-        - secretName: dev2.sofi-platform.dk-tls
-          hosts:
-            - dev2.sofi-platform.dk
+      tls: true
+      annotations:
+        kubernetes.io/ingress.class: "traefik"
       annotations:
         kubernetes.io/ingress.class: "traefik"
 


### PR DESCRIPTION
Næste forsøg på at få logging til at virke. Består af 2 main ændringer:

1. Fikset grafana url path og tls, så nu kan den tilgås på dev2.sofi-platform.dk/grafana/. Det virkede ikke ordentligt tidligere, desuden var tls ikke sat op korrekt før.
2. Øget loglevet på alloy. Der kom næsten ikke nogen logs igennem før sinden den kun opsnappede loglevel > info, men den kunne ikke genkende logleves på det meste så næsten alt blev discarded. Det er ikke sikkert det virker perfekt endnu, men den burde være bedre.

Merge bliver lavet fra en anden branch end logging2 siden jeg derfor kan undgå at ændre "branch: logging2" på logging2 branchen, men kun downstream branchen logging-merge.